### PR TITLE
Update shebang to use bash instead of sh

### DIFF
--- a/dnstest.sh
+++ b/dnstest.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PROVIDERS="
 1.1.1.1#cloudflare 


### PR DESCRIPTION
Bashisms are used in this script and it fails to execute on systems where /bin/sh isn't bash.