### PR TITLE
Fix bug

### DIFF
--- a/dnstest.sh
+++ b/dnstest.sh
@@ -58,7 +58,7 @@ for p in $PROVIDERS; do
         printf "%-8s" "$ttime ms"
         ftime=$((ftime + ttime))
     done
-    avg=`bc <<< "scale=2; $ftime/$totaldomains"`
+    avg=`bc -lq <<< "scale=2; $ftime/$totaldomains"`
 
     echo "  $avg"
 done


### PR DESCRIPTION
You need `-l` option of bc set to get floating points. `-q` suppresses copyright setup.
I guess, other don't needed this since them had a different bc? Or set the options in the bcrc-file.