### PR TITLE
Use parameter expansion to assign pip and pname

### DIFF
--- a/dnstest.sh
+++ b/dnstest.sh
@@ -44,8 +44,8 @@ echo ""
 
 
 for p in $PROVIDERS; do
-    pip=`echo $p| cut -d '#' -f 1`;
-    pname=`echo $p| cut -d '#' -f 2`;
+    pip=${p%%#*}
+    pname=${p##*#}
     ftime=0
 
     printf "%-15s" "$pname"


### PR DESCRIPTION
Instead of using cut to split into pip and pname use parameter expansion