### PR TITLE
Reduce docker container size by using Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM ubuntu:16.04
-RUN apt update && apt install -yq git bc dnsutils
-RUN git clone --depth=1 https://github.com/cleanbrowsing/dnsperftest/ /app
+FROM alpine:latest
+RUN apk --no-cache add bash bc drill \
+    && mkdir /app \
+    && wget https://raw.githubusercontent.com/cleanbrowsing/dnsperftest/master/dnstest.sh -O /app/dnstest.sh \
+    && chmod +x /app/dnstest.sh
 
 ENTRYPOINT ["/app/dnstest.sh"]


### PR DESCRIPTION
The previous Dockerfile which used Ubuntu 16.04 produces a container which is a little over 200MB in size. This PR moves to using Alpine Linux which reduces the resulting container to 8.79MB.