### PR TITLE
fixed alignment of large averages (999.99 >= avg).

### DIFF
--- a/dnstest.sh
+++ b/dnstest.sh
@@ -56,7 +56,8 @@ for p in $NAMESERVERS $PROVIDERS; do
     done
     avg=`bc -lq <<< "scale=2; $ftime/$totaldomains"`
 
-    echo "  $avg"
+    printf "%7s" "$avg"
+    echo ""
 done
 
 


### PR DESCRIPTION
The current code is designed for double-digit averages. I had multiple averages above 100 and it was misaligned in the table. Fixed now.