### PR TITLE
Add dnstest6.sh symlink to test DNS over IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DNS Performance Test
 
-Shell script to test the performance of the most popular DNS resolvers from your location.
+Shell scripts to test the performance of the most popular DNS resolvers from your location, over IPv4 or IPv6.
 
 Includes by default:
  * CloudFlare 1.1.1.1
@@ -9,12 +9,11 @@ Includes by default:
  * Quad9 9.9.9.9
  * Freenom 80.80.80.80
  * OpenDNS
- * Norton
  * CleanBrowsing
  * Yandex
  * AdGuard
  * Neustar
- * Comodo
+ * Comodo (IPv4 only)
 
 # Required 
 
@@ -30,12 +29,12 @@ You need to install bc and dig. For Ubuntu:
  $ git clone --depth=1 https://github.com/cleanbrowsing/dnsperftest/
  $ cd dnsperftest
  $ bash ./dnstest.sh 
+Using providers of DNS over IPv4.
                test1   test2   test3   test4   test5   test6   test7   test8   test9   test10  Average 
 cloudflare     1 ms    1 ms    1 ms    2 ms    1 ms    1 ms    1 ms    1 ms    1 ms    1 ms      1.10
 google         22 ms   1 ms    4 ms    24 ms   1 ms    19 ms   3 ms    56 ms   21 ms   21 ms     17.20
 quad9          10 ms   19 ms   10 ms   10 ms   10 ms   10 ms   10 ms   10 ms   10 ms   55 ms     15.40
 opendns        39 ms   2 ms    2 ms    20 ms   2 ms    72 ms   2 ms    39 ms   39 ms   3 ms      22.00
-norton         2 ms    2 ms    2 ms    2 ms    1 ms    2 ms    2 ms    1 ms    2 ms    2 ms      1.80
 cleanbrowsing  11 ms   14 ms   11 ms   11 ms   10 ms   10 ms   11 ms   36 ms   11 ms   13 ms     13.80
 yandex         175 ms  209 ms  175 ms  181 ms  188 ms  179 ms  178 ms  179 ms  177 ms  208 ms    184.90
 adguard        200 ms  200 ms  200 ms  199 ms  202 ms  200 ms  202 ms  200 ms  199 ms  248 ms    205.00
@@ -43,10 +42,27 @@ neustar        2 ms    2 ms    2 ms    2 ms    1 ms    2 ms    2 ms    2 ms    2
 comodo         21 ms   22 ms   22 ms   22 ms   22 ms   22 ms   22 ms   21 ms   22 ms   24 ms     22.00
 ```
 
+Use `dnstest6.sh` to test DNS over IPv6 instead:
+
+```
+ $ bash ./dnstest6.sh
+Using providers of DNS over IPv6.
+               test1   test2   test3   test4   test5   test6   test7   test8   test9   test10  Average 
+cloudflare     1 ms    1 ms    1 ms    2 ms    1 ms    1 ms    1 ms    1 ms    1 ms    1 ms      1.10
+google         22 ms   1 ms    4 ms    24 ms   1 ms    19 ms   3 ms    56 ms   21 ms   21 ms     17.20
+quad9          10 ms   19 ms   10 ms   10 ms   10 ms   10 ms   10 ms   10 ms   10 ms   55 ms     15.40
+opendns        39 ms   2 ms    2 ms    20 ms   2 ms    72 ms   2 ms    39 ms   39 ms   3 ms      22.00
+cleanbrowsing  11 ms   14 ms   11 ms   11 ms   10 ms   10 ms   11 ms   36 ms   11 ms   13 ms     13.80
+yandex         175 ms  209 ms  175 ms  181 ms  188 ms  179 ms  178 ms  179 ms  177 ms  208 ms    184.90
+adguard        200 ms  200 ms  200 ms  199 ms  202 ms  200 ms  202 ms  200 ms  199 ms  248 ms    205.00
+neustar        2 ms    2 ms    2 ms    2 ms    1 ms    2 ms    2 ms    2 ms    2 ms    2 ms      1.90
+```
+
 To sort with the fastest first, add `sort -k 22 -n` at the end of the command:
 
 ```
   $ bash ./dnstest.sh |sort -k 22 -n
+Using providers of DNS over IPv4.
                test1   test2   test3   test4   test5   test6   test7   test8   test9   test10  Average 
 cloudflare     1 ms    1 ms    1 ms    4 ms    1 ms    1 ms    1 ms    1 ms    1 ms    1 ms      1.30
 norton         2 ms    2 ms    2 ms    2 ms    2 ms    2 ms    2 ms    2 ms    2 ms    2 ms      2.00

--- a/dnstest.sh
+++ b/dnstest.sh
@@ -10,6 +10,8 @@ NAMESERVERS=`cat /etc/resolv.conf | grep ^nameserver | cut -d " " -f 2 | sed 's/
 if [[ $(basename "$0") == *6* ]]; then
 	echo "Using providers of DNS over IPv6."
 	PROVIDERS="
+2001:558:feed::1#comcast
+2001:558:feed::2#comcast2
 2606:4700:4700::1111#cloudflare
 2606:4700:4700::1001#cloudflare2
 2001:4860:4860::8888#google
@@ -25,6 +27,8 @@ if [[ $(basename "$0") == *6* ]]; then
 else
 	echo "Using providers of DNS over IPv4."
 	PROVIDERS="
+75.75.75.75#comcast
+75.75.76.76#comcast2
 1.1.1.1#cloudflare 
 1.0.0.1#cloudflare2
 4.2.2.1#level3 

--- a/dnstest.sh
+++ b/dnstest.sh
@@ -11,7 +11,9 @@ if [[ $(basename "$0") == *6* ]]; then
 	echo "Using providers of DNS over IPv6."
 	PROVIDERS="
 2606:4700:4700::1111#cloudflare
+2606:4700:4700::1001#cloudflare2
 2001:4860:4860::8888#google
+2001:4860:4860::8844#google2
 2620:fe::fe#quad9
 2620:119:35::35#opendns
 2a0d:2a00:1::1#cleanbrowsing
@@ -23,8 +25,10 @@ else
 	echo "Using providers of DNS over IPv4."
 	PROVIDERS="
 1.1.1.1#cloudflare 
+1.0.0.1#cloudflare2
 4.2.2.1#level3 
 8.8.8.8#google 
+8.8.4.4#google2
 9.9.9.9#quad9 
 80.80.80.80#freenom 
 208.67.222.123#opendns 

--- a/dnstest.sh
+++ b/dnstest.sh
@@ -7,20 +7,34 @@ command -v bc > /dev/null || { echo "bc was not found. Please install bc."; exit
 
 NAMESERVERS=`cat /etc/resolv.conf | grep ^nameserver | cut -d " " -f 2 | sed 's/\(.*\)/&#&/'`
 
-PROVIDERS="
+if [[ $(basename "$0") == *6* ]]; then
+	echo "Using providers of DNS over IPv6."
+	PROVIDERS="
+2606:4700:4700::1111#cloudflare
+2001:4860:4860::8888#google
+2620:fe::fe#quad9
+2620:119:35::35#opendns
+2a0d:2a00:1::1#cleanbrowsing
+2a02:6b8::feed:0ff#yandex
+2a00:5a60::ad1:0ff#adguard
+2610:a1:1018::3#neustar
+"
+else
+	echo "Using providers of DNS over IPv4."
+	PROVIDERS="
 1.1.1.1#cloudflare 
 4.2.2.1#level3 
 8.8.8.8#google 
 9.9.9.9#quad9 
 80.80.80.80#freenom 
 208.67.222.123#opendns 
-199.85.126.20#norton 
 185.228.168.168#cleanbrowsing 
 77.88.8.7#yandex 
 176.103.130.132#adguard 
 156.154.70.3#neustar 
 8.26.56.26#comodo
 "
+fi
 
 # Domains to test. Duplicated domains are ok
 DOMAINS2TEST="www.google.com amazon.com facebook.com www.youtube.com www.reddit.com  wikipedia.org twitter.com gmail.com www.google.com whatsapp.com"

--- a/dnstest.sh
+++ b/dnstest.sh
@@ -15,6 +15,7 @@ if [[ $(basename "$0") == *6* ]]; then
 2001:4860:4860::8888#google
 2001:4860:4860::8844#google2
 2620:fe::fe#quad9
+2620:fe::fe:9#quad9_2
 2620:119:35::35#opendns
 2a0d:2a00:1::1#cleanbrowsing
 2a02:6b8::feed:0ff#yandex
@@ -30,6 +31,7 @@ else
 8.8.8.8#google 
 8.8.4.4#google2
 9.9.9.9#quad9 
+149.112.112.112#quad9_2
 80.80.80.80#freenom 
 208.67.222.123#opendns 
 185.228.168.168#cleanbrowsing 

--- a/dnstest6.sh
+++ b/dnstest6.sh
@@ -1,0 +1,1 @@
+dnstest.sh


### PR DESCRIPTION
Using list of IPv6 addresses for public DNS providers from https://kb.adguard.com/en/general/dns-providers.

(Also, removing Norton ConnectSafe DNS which has been shut down: https://en.wikipedia.org/wiki/Norton_ConnectSafe#History)