### PR TITLE
Update output formatting for IPv6 addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 Shell script to test the performance of the most popular DNS resolvers from your location.
 
 Includes by default:
- * CloudFlare 1.1.1.1
- * Level3 4.2.2.1
- * Google 8.8.8.8
- * Quad9 9.9.9.9
- * Freenom 80.80.80.80
- * OpenDNS
- * Norton
- * CleanBrowsing
- * Yandex
- * AdGuard
- * Neustar
- * Comodo
+ * CloudFlare (1.1.1.1)
+ * Level3 (4.2.2.1)
+ * Google (8.8.8.8)
+ * Quad9 (9.9.9.9)
+ * Freenom (80.80.80.80)
+ * OpenDNS (208.67.222.123)
+ * Norton (199.85.126.20)
+ * CleanBrowsing (185.228.168.168)
+ * Yandex (77.88.8.7)
+ * AdGuard (176.103.130.132)
+ * Neustar (156.154.70.3)
+ * Comodo (8.26.56.26)
 
 # Required 
 

--- a/dnstest.sh
+++ b/dnstest.sh
@@ -27,7 +27,7 @@ DOMAINS2TEST="www.google.com amazon.com facebook.com www.youtube.com www.reddit.
 
 
 totaldomains=0
-printf "%-18s" ""
+printf "%-21s" ""
 for d in $DOMAINS2TEST; do
     totaldomains=$((totaldomains + 1))
     printf "%-8s" "test$totaldomains"
@@ -41,7 +41,7 @@ for p in $NAMESERVERS $PROVIDERS; do
     pname=${p##*#}
     ftime=0
 
-    printf "%-18s" "$pname"
+    printf "%-21s" "$pname"
     for d in $DOMAINS2TEST; do
         ttime=`$dig +tries=1 +time=2 +stats @$pip $d |grep "Query time:" | cut -d : -f 2- | cut -d " " -f 2`
         if [ -z "$ttime" ]; then


### PR DESCRIPTION
Commits fix #26 and updates the README to include the default IP addresses.


IPv6 addresses were concatenated with first test result, breaking sorting:
```
%>./dnstest.sh | sort -k 22 -n

                  test1   test2   test3   test4   test5   test6   test7   test8   test9   test10  Average
1.1.1.1           13 ms   13 ms   13 ms   12 ms   13 ms   14 ms   13 ms   14 ms   15 ms   14 ms     13.40
1.0.0.1           13 ms   13 ms   14 ms   14 ms   12 ms   12 ms   12 ms   13 ms   13 ms   14 ms     13.00
2606:4700:4700::111112 ms   13 ms   13 ms   12 ms   13 ms   13 ms   15 ms   12 ms   13 ms   29 ms     14.50
2606:4700:4700::100113 ms   13 ms   13 ms   14 ms   12 ms   13 ms   13 ms   13 ms   12 ms   13 ms     12.90
8.8.8.8           12 ms   13 ms   13 ms   12 ms   16 ms   16 ms   12 ms   15 ms   12 ms   13 ms     13.40
8.8.4.4           12 ms   12 ms   13 ms   14 ms   15 ms   12 ms   12 ms   15 ms   13 ms   13 ms     13.10
2001:4860:4860::8888 16 ms   15 ms   16 ms   23 ms   16 ms   16 ms   13 ms   23 ms   12 ms   16 ms     16.60
2001:4860:4860::8844 13 ms   15 ms   15 ms   20 ms   15 ms   17 ms   14 ms   23 ms   15 ms   23 ms     17.00
```

Changing the printf from 18 to 21 characters will accommodate the IPv6 address width:
```
%> ./dnstest.sh | sort -k 22 -n

                     test1   test2   test3   test4   test5   test6   test7   test8   test9   test10  Average
1.1.1.1              13 ms   13 ms   13 ms   12 ms   13 ms   14 ms   13 ms   14 ms   15 ms   14 ms     13.40
1.0.0.1              13 ms   13 ms   14 ms   14 ms   12 ms   12 ms   12 ms   13 ms   13 ms   14 ms     13.00
2606:4700:4700::1111 12 ms   13 ms   13 ms   12 ms   13 ms   13 ms   15 ms   12 ms   13 ms   29 ms     14.50
2606:4700:4700::1001 13 ms   13 ms   13 ms   14 ms   12 ms   13 ms   13 ms   13 ms   12 ms   13 ms     12.90
8.8.8.8              12 ms   13 ms   13 ms   12 ms   16 ms   16 ms   12 ms   15 ms   12 ms   13 ms     13.40
8.8.4.4              12 ms   12 ms   13 ms   14 ms   15 ms   12 ms   12 ms   15 ms   13 ms   13 ms     13.10
2001:4860:4860::8888 16 ms   15 ms   16 ms   23 ms   16 ms   16 ms   13 ms   23 ms   12 ms   16 ms     16.60
2001:4860:4860::8844 13 ms   15 ms   15 ms   20 ms   15 ms   17 ms   14 ms   23 ms   15 ms   23 ms     17.00
```