### PR TITLE
Removed norton from dnstest.sh

### DIFF
--- a/dnstest.sh
+++ b/dnstest.sh
@@ -14,7 +14,6 @@ PROVIDERS="
 9.9.9.9#quad9 
 80.80.80.80#freenom 
 208.67.222.123#opendns 
-199.85.126.20#norton 
 185.228.168.168#cleanbrowsing 
 77.88.8.7#yandex 
 176.103.130.132#adguard 


### PR DESCRIPTION
Removed norton from list of providers in dnstest.sh as Norton ConnectSafe was discontinued on 15 November 2018.