### PR TITLE
Removed Norton from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Includes by default:
  * Quad9 9.9.9.9
  * Freenom 80.80.80.80
  * OpenDNS
- * Norton
  * CleanBrowsing
  * Yandex
  * AdGuard


### PR DESCRIPTION
Removed Norton from list of tested resolvers in README.md as Norton ConnectSafe was discontinued on 15 November 2018.