### PR TITLE
🚨 shellcheck'ed

### DIFF
--- a/dnstest.sh
+++ b/dnstest.sh
@@ -42,7 +42,7 @@ fi
 providerstotest=$PROVIDERSV4
 
 if [ "$1" = "ipv6" ]; then
-    if [ "$hasipv6" = "" ]; then
+    if [ -z "$hasipv6" ]; then
         echo "error: IPv6 support not found. Unable to do the ipv6 test."; exit 1;
     fi
     providerstotest=$PROVIDERSV6


### PR DESCRIPTION
Before:
```
$ shellcheck dnstest.sh

In dnstest.sh line 8:
NAMESERVERS=`cat /etc/resolv.conf | grep ^nameserver | cut -d " " -f 2 | sed 's/\(.*\)/&#&/'`
            ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                 ^--------------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.

Did you mean:
NAMESERVERS=$(cat /etc/resolv.conf | grep ^nameserver | cut -d " " -f 2 | sed 's/\(.*\)/&#&/')


In dnstest.sh line 46:
        ttime=`$dig +tries=1 +time=2 +stats @$pip $d |grep "Query time:" | cut -d : -f 2- | cut -d " " -f 2`
              ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                                             ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                  ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
        ttime=$($dig +tries=1 +time=2 +stats @"$pip" "$d" |grep "Query time:" | cut -d : -f 2- | cut -d " " -f 2)


In dnstest.sh line 50:
        elif [ "x$ttime" = "x0" ]; then
               ^-------^ SC2268 (style): Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
        elif [ "$ttime" = "0" ]; then


In dnstest.sh line 57:
    avg=`bc -lq <<< "scale=2; $ftime/$totaldomains"`
        ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
    avg=$(bc -lq <<< "scale=2; $ftime/$totaldomains")

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2002 -- Useless cat. Consider 'cmd < file...
  https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of le...
```
After no complains anymore 👍🏻 